### PR TITLE
Add simple Playwright+pytest framework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -205,3 +205,4 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+allure/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,30 @@
-# pythonexample
+# Python Example
+
+Simple Playwright + pytest framework for UI and API testing.
+
+## Quick Start
+1. Install requirements:
+   ```bash
+   pip install -r requirements.txt
+   playwright install
+   ```
+2. Run UI tests:
+   ```bash
+   pytest -m ui
+   ```
+3. Run API tests:
+   ```bash
+   pytest -m api
+   ```
+
+## Folder Map
+```
+.
+├─ pages/          # Page objects for UI tests
+├─ api/            # API client code
+├─ tests/
+│  ├─ ui/          # UI test suites
+│  └─ api/         # API test suites
+├─ config/         # Environment configs
+└─ utils/          # Helpers
+```

--- a/api/client.py
+++ b/api/client.py
@@ -1,0 +1,15 @@
+import requests
+from urllib.parse import urljoin
+
+class ApiClient:
+    def __init__(self, base_url: str):
+        self.base_url = base_url.rstrip('/') + '/'
+        self.session = requests.Session()
+
+    def get(self, path: str, **kwargs):
+        url = urljoin(self.base_url, path.lstrip('/'))
+        return self.session.get(url, **kwargs)
+
+    def post(self, path: str, **kwargs):
+        url = urljoin(self.base_url, path.lstrip('/'))
+        return self.session.post(url, **kwargs)

--- a/config/qa.json
+++ b/config/qa.json
@@ -1,0 +1,4 @@
+{
+    "base_url": "https://example.com",
+    "api_base": "https://jsonplaceholder.typicode.com"
+}

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,29 @@
+import json
+import os
+import pytest
+from playwright.sync_api import sync_playwright
+from api.client import ApiClient
+
+@pytest.fixture(scope='session')
+def cfg():
+    env = os.environ.get('ENV', 'qa')
+    with open(f'config/{env}.json') as f:
+        return json.load(f)
+
+@pytest.fixture(scope='session')
+def api(cfg):
+    return ApiClient(cfg['api_base'])
+
+@pytest.fixture(scope='session')
+def browser():
+    with sync_playwright() as p:
+        browser = p.chromium.launch()
+        yield browser
+        browser.close()
+
+@pytest.fixture
+def page(browser):
+    context = browser.new_context()
+    page = context.new_page()
+    yield page
+    context.close()

--- a/pages/base_page.py
+++ b/pages/base_page.py
@@ -1,0 +1,6 @@
+class BasePage:
+    def __init__(self, page):
+        self.page = page
+
+    def goto(self, url: str):
+        self.page.goto(url)

--- a/pages/login_page.py
+++ b/pages/login_page.py
@@ -1,0 +1,14 @@
+from .base_page import BasePage
+
+class LoginPage(BasePage):
+    def __init__(self, page, base_url: str):
+        super().__init__(page)
+        self.base_url = base_url.rstrip('/')
+
+    def load(self):
+        self.goto(self.base_url)
+
+    def login(self, username: str, password: str):
+        self.page.fill('#username', username)
+        self.page.fill('#password', password)
+        self.page.click('button[type="submit"]')

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,6 @@
+[pytest]
+markers =
+    ui: ui tests
+    api: api tests
+    smoke: smoke tests
+addopts = -ra

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+pytest
+pytest-playwright
+playwright
+pytest-xdist
+python-dotenv
+requests
+allure-pytest

--- a/tests/api/test_users.py
+++ b/tests/api/test_users.py
@@ -1,0 +1,7 @@
+import pytest
+
+@pytest.mark.api
+def test_get_users(api):
+    resp = api.get('/users')
+    assert resp.status_code == 200
+    assert isinstance(resp.json(), list)

--- a/tests/ui/test_login.py
+++ b/tests/ui/test_login.py
@@ -1,0 +1,8 @@
+import pytest
+from pages.login_page import LoginPage
+
+@pytest.mark.ui
+def test_open_login_page(page, cfg):
+    login = LoginPage(page, cfg['base_url'])
+    login.load()
+    assert page.title() != ''

--- a/utils/waiters.py
+++ b/utils/waiters.py
@@ -1,0 +1,9 @@
+import time
+
+def wait_for(condition_fn, timeout=5, interval=0.1):
+    start = time.time()
+    while time.time() - start < timeout:
+        if condition_fn():
+            return True
+        time.sleep(interval)
+    raise TimeoutError('condition not met within timeout')


### PR DESCRIPTION
## Summary
- create base Playwright+pytest project structure
- add example API client and page objects
- implement sample UI and API tests
- provide config and helper utilities

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'playwright')*

------
https://chatgpt.com/codex/tasks/task_e_686a7c96ec648320bdcbd5c700cc7586